### PR TITLE
Updates image tag to 7.1.0-ga1-1.6

### DIFF
--- a/wedeploy.json
+++ b/wedeploy.json
@@ -1,6 +1,6 @@
 {
   "id": "liferay",
-  "image": "wedeploy/liferay:7.1.0-ga1-1.4",
+  "image": "wedeploy/liferay:7.1.0-ga1-1.6",
   "memory": 4096,
   "cpu": 3,
   "healthCheck": {


### PR DESCRIPTION
latest is `7.1.0-ga1-1.6`, per https://cloud.docker.com/u/wedeploy/repository/docker/wedeploy/liferay/tags